### PR TITLE
Change spelling of omnivore in tab group to match definition

### DIFF
--- a/src/components/TabGroup.js
+++ b/src/components/TabGroup.js
@@ -12,7 +12,7 @@ export default function TabGroup() {
                 <ul className="nav">
                     <li className="nav-item">
                         <NavLink to="/"
-                            className='nav-link'> <i class="fa fa-car"></i> Ominivore</NavLink>
+                            className='nav-link'> <i class="fa fa-car"></i> Omnivore</NavLink>
                     </li>
                     <li className="nav-item">
                         <NavLink to="/carnivore"

--- a/src/components/types/ominivore/Ominivore.jsx
+++ b/src/components/types/ominivore/Ominivore.jsx
@@ -10,7 +10,7 @@ export default function Ominivore() {
         <div className='container'>
             <Welcome />
             <div className="row typeContent">
-                <h2 className="heading">Ominivores</h2>
+                <h2 className="heading">Omnivores</h2>
                 <p className="text">An omnivore is a person who eats all types of food.  The word omnivore literally translates to “all devour.” These eaters do not discriminate against any individual food group and will eat pretty much anything that is served to them.</p>
                 <Breakfast />
                 <Lunch />


### PR DESCRIPTION
Left the function definition unchanged so that component does not break. Only changed spelling of text that is visible in the UI.