### PR TITLE
fixed overflowing content in home page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -83,7 +83,8 @@ li {
   padding: 2% 1.5%;
   border-radius: 7px;
   margin-bottom: 5%;
-  height: 70vh;
+  /*height: 70vh;*/
+  height: auto;
 }
 
 .btns {


### PR DESCRIPTION
Fixed content spilling out of the content box in Home page at smaller screen sizes. 
Fix: 
Instead of fixing a height, set height to auto, so it auto adjust to the content.